### PR TITLE
fix: wrap fsPaths in quotes

### DIFF
--- a/src/packageRunner/optionsBuilderBase.ts
+++ b/src/packageRunner/optionsBuilderBase.ts
@@ -48,7 +48,7 @@ export class OptionsBuilderBase implements IOptionsBuilder {
     );
     const options = ['-m', this._packageInfo.packageName];
     if (uris.length > 0) {
-      options.push(...uris.map(uri => `${uri.fsPath.replace(/\\/g, '/')}`));
+      options.push(...uris.map(uri => `"${uri.fsPath.replace(/\\/g, '/')}"`));
     }
     return Promise.resolve(options);
   }


### PR DESCRIPTION
### Description of change
This pull request includes a small but significant change to the `OptionsBuilderBase` class in the `src/packageRunner/optionsBuilderBase.ts` file. The change ensures that URIs are properly quoted when added to the options array.

* [`src/packageRunner/optionsBuilderBase.ts`](diffhunk://#diff-a22d956d677fc74978af6358efbb056cb299f1cf9da81f8f96f7766cf250ed44L51-R51): Modified the `options.push` line to wrap each URI in double quotes to handle paths with spaces correctly.
 
This should fix the issue of directories or file names with spaces causing issues when running commands

Related to https://github.com/34j/vscode-autoflake-extension/issues/61

<!--
  😀 Wonderful!  Thank you for opening a pull request.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [ ] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

<!--
  🎉 Thank you for contributing!
-->
